### PR TITLE
Fix loading issue for non text-generation models

### DIFF
--- a/llmserve/backend/server/run.py
+++ b/llmserve/backend/server/run.py
@@ -68,7 +68,8 @@ def llm_server(args: Union[str, LLMApp, List[Union[LLMApp, str]]]):
         deployment_config = deployment_config.copy()
         max_concurrent_queries = deployment_config.pop(
             "max_concurrent_queries", None
-        ) or user_config["model_config"]["generation"].get("max_batch_size", 1)
+        ) or user_config.get("model_config", {}).get("generation", {}).get("max_batch_size", 1)
+
         deployments[model.model_config.model_id] = LLMDeployment.options(
             name=_reverse_prefix(model.model_config.model_id),
             max_concurrent_queries=max_concurrent_queries,

--- a/models/image-to-text--nlpconnect--vit-gpt2-image-captioning.yaml
+++ b/models/image-to-text--nlpconnect--vit-gpt2-image-captioning.yaml
@@ -1,4 +1,5 @@
 deployment_config:
+  max_concurrent_queries: 1
   autoscaling_config:
     min_replicas: 1
     initial_replicas: 1

--- a/models/question-answering--deepset--roberta-base-squad2.yaml
+++ b/models/question-answering--deepset--roberta-base-squad2.yaml
@@ -1,4 +1,5 @@
 deployment_config:
+  max_concurrent_queries: 1
   autoscaling_config:
     min_replicas: 1
     initial_replicas: 1

--- a/models/summarization--facebook--bart-large-cnn.yaml
+++ b/models/summarization--facebook--bart-large-cnn.yaml
@@ -1,4 +1,5 @@
 deployment_config:
+  max_concurrent_queries: 1
   autoscaling_config:
     min_replicas: 1
     initial_replicas: 1

--- a/models/text-classification--distilbert-base-uncased-finetuned-sst-2-english.yaml
+++ b/models/text-classification--distilbert-base-uncased-finetuned-sst-2-english.yaml
@@ -1,4 +1,5 @@
 deployment_config:
+  max_concurrent_queries: 1
   autoscaling_config:
     min_replicas: 1
     initial_replicas: 1

--- a/models/translation--flan-t5-small.yaml
+++ b/models/translation--flan-t5-small.yaml
@@ -1,4 +1,5 @@
 deployment_config:
+  max_concurrent_queries: 1
   autoscaling_config:
     min_replicas: 1
     initial_replicas: 1

--- a/models/translation--t5-small.yaml
+++ b/models/translation--t5-small.yaml
@@ -1,4 +1,5 @@
 deployment_config:
+  max_concurrent_queries: 1
   autoscaling_config:
     min_replicas: 1
     initial_replicas: 1


### PR DESCRIPTION
It's about `max_concurrent_queries`.
`text-generation` models could get this parameters from `model_config.generation` but non-textgeneration models has no `generation` section, so it raise error.

So add `deployment_config.max_concurrent_queries` for non-textgeneration models