### PR TITLE
Fix output issue for default transformers pipeline

### DIFF
--- a/llmserve/backend/llm/pipelines/default_transformers_pipeline.py
+++ b/llmserve/backend/llm/pipelines/default_transformers_pipeline.py
@@ -57,7 +57,7 @@ class DefaultTransformersPipeline(BasePipeline):
 
         self.pipeline = None
         self.preprocess = None
-        #self.postprocess = None
+        self.postprocess = None
 
     def _get_transformers_pipeline(self, **kwargs) -> TransformersPipeline:
         logger.info(f"DefaultTransformersPipeline.device: {self.device}")


### PR DESCRIPTION
Note that there are postprocess function which is conficts, so I use another function name. @depenglee1707 @SeanHH86 

Unite test result:
```
(llm) jason@JasondeMacBook-Pro llm-inference % llm-serve predict --model facebook/opt-125m --appname test --prompt "What can I do" --prompt "this is a test"
[2024-03-01 17:34:00,923] [INFO] [real_accelerator.py:161:get_accelerator] Setting ds_accelerator to mps (auto detect)
[2024-03-01 17:34:01,054] torch.distributed.elastic.multiprocessing.redirects: [WARNING] NOTE: Redirects are currently not supported in Windows or MacOs.
[INFO 2024-03-01 17:34:04,466] config.py: 58  PyTorch version 2.1.2 available.
{
    'generated_text': "What can I do\nI've got a few things to offer you.\nJust want to say thank you for being so nice. I'm really sorry I couldn't help you out, but
I just wanted to let you know that I love you and that I'll be here for you.  *Edit:* Thank you for your kind words. I'm glad to hear that you're happy and have a
great time!\nThank you very much. It's been a while since I've been here, so I don't know how I was supposed to feel about it. I just wanted to make sure I didn't
make any mistakes in the process.",
    'num_input_tokens': 5,
    'num_input_tokens_batch': 5,
    'num_generated_tokens': 134,
    'num_generated_tokens_batch': 134,
    'preprocessing_time': 5.024997517466545e-05,
    'generation_time': 1.1034569169860333,
    'postprocessing_time': 0.001611500047147274,
    'generation_time_per_token': 0.007938538971122542,
    'generation_time_per_token_batch': 0.007938538971122542,
    'num_total_tokens': 139,
    'num_total_tokens_batch': 139,
    'total_time': 1.1051186670083553,
    'total_time_per_token': 0.007950494007254354,
    'total_time_per_token_batch': 0.007950494007254354
}
{
    'generated_text': 'this is a test\nThis is a test for the next time I\'m going to use this test.  This is my first time posting on Reddit, and I thought it was
cool to see how far we\'re from being able to use the word "test".\nI like the idea of using that term in the future.\nIt\'s not a good one at all. It\'s too generic,
and I feel like it should be used more often.',
    'num_input_tokens': 5,
    'num_input_tokens_batch': 5,
    'num_generated_tokens': 93,
    'num_generated_tokens_batch': 93,
    'preprocessing_time': 1.4170072972774506e-06,
    'generation_time': 0.6898609159979969,
    'postprocessing_time': 0.0010639999527484179,
    'generation_time_per_token': 0.007039397102020377,
    'generation_time_per_token_batch': 0.007039397102020377,
    'num_total_tokens': 98,
    'num_total_tokens_batch': 98,
    'total_time': 0.6909263329580426,
    'total_time_per_token': 0.007050268703653496,
    'total_time_per_token_batch': 0.007050268703653496
}

(llm) jason@JasondeMacBook-Pro llm-inference % curl -H "Content-Type: application/json" -X POST -d '{"prompt": "What can I do"}' "http://0.0.0.0:8000/api/v1/test/facebook--opt-125m/run/predict"
{"generated_text":"What can I do\n\nYou have to start a new project and keep working on it. If you are not happy with the way things are going, then you should take a look at your project and see if there is something you can improve. You might be surprised to learn that you need to work on several different projects to make sure that they are working correctly.\n\nWhen you finish your project, you will need to start a new project again. It is important that you have a good understanding of what you want to do with your project and what you can do with it. You can always do more work in order to ensure that you have a better","num_input_tokens":5,"num_input_tokens_batch":5,"num_generated_tokens":134,"num_generated_tokens_batch":134,"preprocessing_time":2.3667002096772194e-05,"generation_time":1.1111444169655442,"postprocessing_time":0.007100458024069667,"generation_time_per_token":0.007993844726370821,"generation_time_per_token_batch":0.007993844726370821,"num_total_tokens":139,"num_total_tokens_batch":139,"total_time":1.1182685419917107,"total_time_per_token":0.008045097424400797,"total_time_per_token_batch":0.008045097424400797}
```