### PR TITLE
Remove initializer: transformerpipeline

### DIFF
--- a/llmserve/backend/llm/initializers/__init__.py
+++ b/llmserve/backend/llm/initializers/__init__.py
@@ -5,7 +5,6 @@ from .hf_transformers import (
     DeviceMapInitializer,
     SingleDeviceInitializer,
     FinetuneInitializer,
-    TransformersPipelineInitializer,
     AutoModelInitializer,
 )
 
@@ -33,6 +32,5 @@ __all__ = [
     "FinetuneInitializer",
     "AutoModelInitializer",
     "LlamaCppInitializer",
-    "TransformersPipelineInitializer",
     "VllmInitializer",
 ]

--- a/llmserve/backend/llm/initializers/hf_transformers/__init__.py
+++ b/llmserve/backend/llm/initializers/hf_transformers/__init__.py
@@ -1,4 +1,4 @@
-from .base import DeviceMapInitializer, SingleDeviceInitializer, TransformersInitializer, FinetuneInitializer, AutoModelInitializer, TransformersPipelineInitializer
+from .base import DeviceMapInitializer, SingleDeviceInitializer, TransformersInitializer, FinetuneInitializer, AutoModelInitializer
 from .deepspeed import DeepSpeedInitializer
 
 __all__ = [
@@ -7,6 +7,5 @@ __all__ = [
     "DeepSpeedInitializer",
     "TransformersInitializer",
     "FinetuneInitializer",
-    "TransformersPipelineInitializer",
     "AutoModelInitializer",
 ]

--- a/llmserve/backend/llm/initializers/hf_transformers/base.py
+++ b/llmserve/backend/llm/initializers/hf_transformers/base.py
@@ -291,7 +291,7 @@ class DeviceMapInitializer(TransformersInitializer):
 
     def _get_model_from_pretrained_kwargs(self):
         return dict(
-            low_cpu_mem_usage=True,
+            # low_cpu_mem_usage=True,
             torch_dtype=self.dtype,
             device_map=self.device_map,
             **self.from_pretrained_kwargs,
@@ -337,6 +337,7 @@ class SingleDeviceInitializer(TransformersInitializer):
         return dict(
             # low_cpu_mem_usage=True,   //should move to config yaml file of mode
             torch_dtype=self.dtype,
+            device = self.device,
             **self.from_pretrained_kwargs,
         )
 
@@ -346,54 +347,7 @@ class SingleDeviceInitializer(TransformersInitializer):
     def postprocess_model(self, model: "PreTrainedModel") -> "PreTrainedModel":
         logger.info(
             f"SingleDeviceInitializer postprocess_model to device {self.device}")
-        return super().postprocess_model(model.to(device=self.device))
-
-
-class TransformersPipelineInitializer(LLMInitializer):
-    """Initialize model and tokenizer and place them on the correct device.
-
-    actually do nothing, need further research TODO
-
-    Args:
-        device (torch.device): Device to place model and tokenizer on.
-        world_size (int): Number of GPUs to use.
-        dtype (torch.dtype, optional): Data type to use. Defaults to torch.float16.
-        use_bettertransformer (bool, optional): Whether to use BetterTransformer. Defaults to False.
-        torch_compile (Optional[Dict[str, Any]], optional): Parameters for ``torch.compile``. Defaults to None.
-        **from_pretrained_kwargs: Keyword arguments for ``AutoModel.from_pretrained``.
-    """
-
-    def __init__(
-        self,
-        device: torch.device,
-        world_size: int,
-        dtype: torch.dtype = torch.float16,
-        use_bettertransformer: bool = False,
-        torch_compile: Optional[Dict[str, Any]] = None,
-        **from_pretrained_kwargs,
-    ):
-        self.device = device
-        self.world_size = world_size
-        self.dtype = dtype
-        self.from_pretrained_kwargs = from_pretrained_kwargs
-        self.use_bettertransformer = use_bettertransformer
-        self.torch_compile = torch_compile
-
-    def load_model(self, model_id: str) -> "PreTrainedModel":
-        pass
-
-    def load_tokenizer(self, tokenizer_id: str) -> "PreTrainedTokenizer":
-        pass
-
-    def _get_model_from_pretrained_kwargs(self):
-        return dict(
-            # low_cpu_mem_usage=True,   //should move to config yaml file of mode
-            torch_dtype=self.dtype,
-            **self.from_pretrained_kwargs,
-        )
-
-    def get_model_from_pretrained_kwargs(self):
-        return self._get_model_from_pretrained_kwargs()
+        return super().postprocess_model(model.to(device=self.device))  
 
 
 # should be remove soon

--- a/llmserve/backend/llm/pipelines/default_transformers_pipeline.py
+++ b/llmserve/backend/llm/pipelines/default_transformers_pipeline.py
@@ -155,6 +155,7 @@ class DefaultTransformersPipeline(BasePipeline):
         logger.info(
             f"DefaultTransformersPipeline default_kwargs {default_kwargs}")
         logger.info(f"DefaultTransformersPipeline model_kwargs {model_kwargs}")
+        
         transformers_pipe = pipeline(
             **default_kwargs,
             model_kwargs=model_kwargs,

--- a/llmserve/backend/server/config.py
+++ b/llmserve/backend/server/config.py
@@ -64,9 +64,8 @@ LLMTEMPLATE_MODEL_CONFIG_EXPERIMENTAL = {
         "runtime_env": {
         },
         "initializer": {
-            "type": "TransformersPipeline",
+            "type": "SingleDevice",
             "dtype": "float32",
-            "use_fast": False,
             "from_pretrained_kwargs": {
                 "use_cache": True,
                 "trust_remote_code": True

--- a/llmserve/backend/server/models.py
+++ b/llmserve/backend/server/models.py
@@ -232,7 +232,7 @@ class Transformers(Initializer, extra=Extra.forbid):
 
     @property
     def allowed_pipelines(self) -> Set[str]:
-        return {"default"}
+        return {"default", "defaulttransformers"}
 
 
 class DeepSpeed(Transformers):
@@ -283,29 +283,6 @@ class LlamaCpp(Initializer):
     def allowed_pipelines(self) -> Set[str]:
         return {"llamacpp"}
 
-
-class TransformersPipeline(Initializer):
-    type: Literal["TransformersPipeline"]
-    use_fast: bool = False
-    dtype: str = "float16"
-    from_pretrained_kwargs: Dict[str, Any] = {}
-
-    @property
-    def torch_dtype(self) -> torch.dtype:
-        return getattr(torch, self.dtype)
-
-    def get_initializer_kwargs(self) -> dict:
-        return {
-            **self.dict(exclude={"type", "from_pretrained_kwargs", "dtype"}),
-            "dtype": self.torch_dtype,
-            **self.from_pretrained_kwargs,
-        }
-
-    @property
-    def allowed_pipelines(self) -> Set[str]:
-        return {"defaulttransformers"}
-
-
 class Vllm(Initializer):
     type: Literal["Vllm"]
     from_pretrained_kwargs: Dict[str, Any] = {}
@@ -339,7 +316,7 @@ class S3MirrorConfig(BaseModelExtended):
 class InitializationConfig(BaseModelExtended):
     initializer: Annotated[
         Union[DeepSpeed, DeviceMap, SingleDevice, Finetune, AutoModel,
-              LlamaCpp, TransformersPipeline, Vllm], Field(discriminator="type")
+              LlamaCpp, Vllm], Field(discriminator="type")
     ]
     pipeline: Union[Literal["default"], Literal["defaulttransformers"],
                     Literal["llamacpp"], Literal["vllm"]] = None

--- a/models/image-to-text--nlpconnect--vit-gpt2-image-captioning.yaml
+++ b/models/image-to-text--nlpconnect--vit-gpt2-image-captioning.yaml
@@ -21,7 +21,7 @@ model_config:
     # s3_mirror_config:
     #   bucket_uri: s3://large-dl-models-mirror/models--amazon--LightGPT/main-safetensors/
     initializer:
-      type: TransformersPipeline
+      type: SingleDevice
       use_fast: False
       dtype: float32
       from_pretrained_kwargs:

--- a/models/question-answering--deepset--roberta-base-squad2.yaml
+++ b/models/question-answering--deepset--roberta-base-squad2.yaml
@@ -21,7 +21,7 @@ model_config:
     # s3_mirror_config:
     #   bucket_uri: s3://large-dl-models-mirror/models--amazon--LightGPT/main-safetensors/
     initializer:
-      type: TransformersPipeline
+      type: SingleDevice
       use_fast: False
       dtype: float32
       from_pretrained_kwargs:

--- a/models/summarization--facebook--bart-large-cnn.yaml
+++ b/models/summarization--facebook--bart-large-cnn.yaml
@@ -21,7 +21,7 @@ model_config:
     # s3_mirror_config:
     #   bucket_uri: s3://large-dl-models-mirror/models--amazon--LightGPT/main-safetensors/
     initializer:
-      type: TransformersPipeline
+      type: SingleDevice
       dtype: float32
       use_fast: False
       from_pretrained_kwargs:

--- a/models/translation--flan-t5-small.yaml
+++ b/models/translation--flan-t5-small.yaml
@@ -21,7 +21,7 @@ model_config:
     s3_mirror_config:
       bucket_uri: /tmp/hub/models/flan-t5-small/
     initializer:
-      type: TransformersPipeline
+      type: SingleDevice
       use_fast: False
       dtype: float32
       from_pretrained_kwargs:

--- a/models/translation--t5-small.yaml
+++ b/models/translation--t5-small.yaml
@@ -21,7 +21,7 @@ model_config:
     # s3_mirror_config:
     #   bucket_uri: s3://large-dl-models-mirror/models--amazon--LightGPT/main-safetensors/
     initializer:
-      type: TransformersPipeline
+      type: SingleDevice
       use_fast: False
       dtype: float32
       from_pretrained_kwargs:


### PR DESCRIPTION
The original `initializer`: `transformerpipeline` is a dummy one just for `pipeline`: `defaulttransformers` to make the design consistency, but it dose not consider the `device` the model load on.

So, decide to reuse `singleDevice` and `devicemap`.