### PR TITLE
fix max-token conflict w/ DS

### DIFF
--- a/llmserve/backend/llm/predictor.py
+++ b/llmserve/backend/llm/predictor.py
@@ -19,6 +19,7 @@ from llmserve.backend.llm.utils import (
     init_torch_dist_process_group_async,
     initialize_node,
     timeit,
+    get_max_token_size,
 )
 from llmserve.backend.logger import get_logger
 from llmserve.backend.server.models import Args, LLMConfig, Prompt, Response
@@ -94,7 +95,7 @@ def init_model(
 
     if llm_config.warmup and warmup_inputs:
         prowarmup_inputs_max = Prompt(prompt=warmup_inputs * (
-            int(llm_config.max_input_words / (len(warmup_inputs.split()) + 1)) + 1
+            int(get_max_token_size(llm_config) / (len(warmup_inputs.split()) + 1))
         ), use_prompt_format=False)
 
         logger.info(

--- a/models/text-generation--bigscience--bloom-3b.yaml
+++ b/models/text-generation--bigscience--bloom-3b.yaml
@@ -32,8 +32,8 @@ model_config:
         trust_remote_code: true
     pipeline: default
   generation:
-    max_batch_size: 2
-    batch_wait_timeout_s: 30
+    max_batch_size: 10
+    batch_wait_timeout_s: 0
     generate_kwargs:
       do_sample: false
       max_new_tokens: 512


### PR DESCRIPTION
To fix max input token size for warmup. w/ DS, there is "max_tokens" localed "initializer/max_tokens", it will conflict with "max_input_words", prefer "max_tokens" if both existed 
