### PR TITLE
Refactor the solution of vllm integration

### DIFF
--- a/llmserve/backend/llm/engines/__init__.py
+++ b/llmserve/backend/llm/engines/__init__.py
@@ -1,0 +1,29 @@
+from typing import TYPE_CHECKING, Type
+from llmserve.backend.logger import get_logger
+
+logger = get_logger(__name__)
+
+
+if TYPE_CHECKING:
+    from ._base import LLMEngine
+
+from .generic import GenericEngine
+try:
+    from .vllm import VllmEngine
+except ImportError:
+    logger.info("Import vllm related stuff failed, please make sure 'vllm' is installed.")
+
+def get_engine_cls_by_name(name: str) -> Type["LLMEngine"]:
+    lowercase_globals = {k.lower(): v for k, v in globals().items()}
+    ret = lowercase_globals.get(
+        f"{name.lower()}engine", lowercase_globals.get(name.lower(), None)
+    )
+    assert ret
+    return ret
+
+
+__all__ = [
+    "get_engine_cls_by_name",
+    "GenericEngine",
+    "VllmEngine",
+]

--- a/llmserve/backend/llm/engines/_base.py
+++ b/llmserve/backend/llm/engines/_base.py
@@ -1,0 +1,66 @@
+from abc import ABC, abstractmethod
+from typing import List, Optional, Any
+from ray.air import ScalingConfig
+from ray.util.placement_group import PlacementGroup
+from llmserve.backend.server.models import Prompt
+
+from llmserve.backend.logger import get_logger
+
+from typing import List, Optional
+from ray.air import ScalingConfig
+
+from llmserve.backend.logger import get_logger
+from llmserve.backend.server.models import Args, Prompt
+import asyncio
+
+logger = get_logger(__name__)
+
+class LLMEngine(ABC):
+    args: Args = None
+    """Initialize model and tokenizer and place them on the correct device.
+
+    Args:
+        device (torch.device): Device to place model and tokenizer on.
+        world_size (int): Number of GPUs to use.
+    """
+
+    def __init__(
+        self,
+        args: Args,
+
+    ):
+        self.args = args
+
+    @abstractmethod
+    async def launch_engine(
+            self, 
+            scaling_config: ScalingConfig,
+            placement_group: PlacementGroup,
+            scaling_options: dict,
+        ) -> Any:
+        """Load model.
+
+        Args:
+            model_id (str): Hugging Face model ID.
+        """
+        pass
+
+    @abstractmethod
+    async def predict(
+            self,
+            prompts: List[Prompt],
+            *,
+            timeout_s: float = 60,
+            start_timestamp: Optional[float] = None,
+            lock: asyncio.Lock,
+        ) -> List[str]:
+        """Load model.
+
+        Args:
+            model_id (str): Hugging Face model ID.
+        """
+        pass
+    
+    @abstractmethod
+    async def check_health(self):
+        pass

--- a/llmserve/backend/llm/engines/generic.py
+++ b/llmserve/backend/llm/engines/generic.py
@@ -1,0 +1,419 @@
+import torch
+from typing import List, Optional, Any
+from ray.air import ScalingConfig
+from ray.util.placement_group import PlacementGroup
+from llmserve.backend.server.models import Prompt
+
+from llmserve.backend.logger import get_logger
+
+import asyncio
+import gc
+import os
+import traceback
+from typing import List, Optional
+
+import ray
+import ray.util
+import torch
+import torch.backends.cuda
+from ray.air import ScalingConfig
+from ray.air.util.torch_dist import TorchDistributedWorker
+
+from llmserve.backend.llm.initializers import get_initializer_cls_by_name
+from llmserve.backend.llm.pipelines import get_pipeline_cls_by_name
+from llmserve.backend.llm.pipelines._base import BasePipeline
+from llmserve.backend.llm.utils import (
+    init_torch_dist_process_group_async,
+    timeit,
+    get_max_token_size,
+)
+from llmserve.backend.logger import get_logger
+from llmserve.backend.server.models import Args, LLMConfig, Prompt, Response
+from llmserve.backend.server.utils import render_gradio_params
+from ._base import LLMEngine
+logger = get_logger(__name__)
+
+@timeit
+def init_model(
+    llm_config: LLMConfig,
+    world_size: int,
+    local_rank: int,
+    max_batch_size: Optional[int] = None,
+):
+    """Initialize the model.
+
+    Args:
+        llm_config (LLM): LLM configuration.
+        world_size (int): Number of GPUs.
+        local_rank (int): Local rank of the current GPU.
+        max_batch_size (Optional[int], optional): Maximum batch size. Defaults to None.
+    """
+    logger.info(
+        f"Initializing model {llm_config.model_id} with local_rank: {local_rank}")
+
+    # Lazy import so that the new cache location is used
+    torch.backends.cuda.matmul.allow_tf32 = True
+    if torch.cuda.is_available():
+        device = torch.device(f"cuda:{local_rank}")
+        # device = torch.device("cuda")
+    else:
+        device = torch.device("cpu")
+
+    initializer_name = llm_config.initialization.initializer
+    if not isinstance(initializer_name, str):
+        initializer_name = initializer_name.type
+
+    logger.info(f"Initializer name is {initializer_name} on device {device}")
+    initializer = get_initializer_cls_by_name(initializer_name)(
+        device=device,
+        world_size=world_size,
+        **llm_config.initialization.initializer.get_initializer_kwargs(),
+    )
+
+    pipeline_name = llm_config.initialization.pipeline
+    additional_kwargs = dict(
+        task=llm_config.model_task,
+    )
+    logger.info(f"Pipeline name is {pipeline_name} on device {device}")
+    pipeline = get_pipeline_cls_by_name(pipeline_name).from_initializer(
+        initializer,
+        llm_config.actual_hf_model_id,
+        prompt_format=(
+            llm_config.generation.prompt_format if llm_config.generation else None),
+        device=device,
+        **additional_kwargs
+    )
+
+    # Warmup
+    # For DS w/ kernel inject, first batch the model gets MUST be of maximum batch size,
+    # otherwise subsequent batches with more entries than the first batch
+    # will raise CUDA errors if use_kernel=True.
+    batch_size = max_batch_size or 1
+
+    logger.info(f"Model {llm_config.model_id} batch_size is {batch_size}")
+    model_task_info = render_gradio_params(llm_config.model_task)
+    warmup_inputs = model_task_info["warmup"] if "warmup" in model_task_info else None
+
+    if llm_config.warmup and warmup_inputs:
+        prowarmup_inputs_max = Prompt(prompt=warmup_inputs * (
+            int(get_max_token_size(llm_config) / (len(warmup_inputs.split()) + 1))
+        ), use_prompt_format=False)
+
+        logger.info(
+            f"Model {llm_config.model_id} is warming up, input is {warmup_inputs}...")
+        if llm_config.generation:
+            generate_kwargs = llm_config.generation.all_generate_kwargs.copy()
+            if "max_new_tokens" in generate_kwargs:
+                generate_kwargs["min_new_tokens"] = generate_kwargs["max_new_tokens"]
+        else:
+            generate_kwargs = {}
+
+    warmup_success = False
+    while not warmup_success and llm_config.warmup and warmup_inputs:
+        try:
+            logger.info("start to test with single prompt")
+            logger.info(f"warmpup prompt is: {warmup_inputs}")
+            resp = generate(
+                [Prompt(prompt=warmup_inputs, use_prompt_format=False)],
+                pipeline,
+                **generate_kwargs,
+            )
+            logger.info(f"warmpup response is {str(resp)}")
+            assert len(resp) > 0
+            assert all(x.generated_text for x in resp)
+
+            logger.info("start to test with max batch prompts, try to find a suitable batch size")
+            assert batch_size > 0
+            resp_batch = generate(
+                [prowarmup_inputs_max] * batch_size,
+                pipeline,
+                **generate_kwargs,
+            )
+            logger.info(str(resp_batch))
+            assert len(resp_batch) == batch_size
+            assert all(x.generated_text for x in resp_batch)
+
+            warmup_success = True
+        except torch.cuda.OutOfMemoryError:
+            batch_size -= 2
+            logger.warning(
+                f"Warmup failed due to CUDA OOM, reducing batch size to {batch_size}")
+
+    logger.info(
+        f"Model {llm_config.model_id} succesfully initialized, final batch size {batch_size}!")
+
+    gc.collect()
+
+    return pipeline
+
+
+@timeit
+def generate(
+    prompts: List[Prompt], pipeline: BasePipeline, **generate_kwargs
+) -> List[Response]:
+    """Generate predictions using a Pipeline.
+
+    Args:
+        prompts (List[Prompt]): List of prompts.
+        pipeline (BasePipeline): Pipeline to use.
+        **generate_kwargs: Keyword arguments to pass to the pipeline's `generate` method.
+    """
+    logger.info(f"Call pipeline with generate_kwargs: {generate_kwargs}")
+    outputs = pipeline(
+        prompts,
+        **generate_kwargs,
+    )
+    return outputs
+
+import logging
+@ray.remote
+class PredictionWorker(TorchDistributedWorker):
+    """A PredictionWorker is a Ray remote actor that runs a single shard of a DeepSpeed job.
+
+    Multiple PredictionWorkers of the same WorkerGroup will form a PyTorch DDP process
+    group and work together under the orchestration of DeepSpeed.
+
+    Args:
+        llm_config (LLM): LLM configuration.
+        world_size (int): Number of GPUs.
+    """
+
+    def __init__(self, llm_config: LLMConfig, world_size: int):
+        self.llm_config = llm_config
+        self.world_size = world_size
+
+    def init_model(
+        self,
+        local_rank: int,
+        num_cpus_per_worker: int = 1,
+        num_gpus_per_worker: int = 0,
+    ):
+        """Initialize model for inference.
+
+        Args:
+            local_rank (int): Local rank of the current GPU.
+            num_cpus_per_worker (int, optional): Number of CPUs to use per worker. Defaults to 1.
+        """
+        
+        # Recreate the logger to make sure it takes precedence over
+        # other logger configurations.
+        # get_logger(__name__, force=True)
+
+        # for DDP, comment now, still consider if ddp is a case
+        # rank = torch.distributed.get_rank()
+        # logger.info(rank)
+
+        logger.info(
+            f"num_gpus_per_worker: {num_gpus_per_worker}, num_cpus_per_worker: {num_cpus_per_worker}")
+        os.environ["OMP_NUM_THREADS"] = str(int(num_cpus_per_worker))
+
+        logger.info("Prediction Worker calling init model")
+        self.generator = init_model(
+            self.llm_config,
+            self.world_size,
+            local_rank,
+            max_batch_size=(
+                self.llm_config.generation.max_batch_size if self.llm_config.generation else None),
+        )
+
+    def generate(
+        self,
+        data: List[Prompt],
+        *,
+        timeout_s: Optional[float] = None,
+        start_timestamp: Optional[float] = None,
+        oom_retry: bool = True,
+        **kwargs,
+    ) -> List[str]:
+        """Generate text from prompts.
+
+        Args:
+            data (List[Prompt]): Batch of prompts.
+            timeout_s (Optional[float], optional): Timeout for the generation.
+                Ignored if start_timestamp is None.
+            start_timestamp (Optional[float], optional): Timestamp of when the
+                batch was created. Defaults to None. If set, will early stop
+                the generation. Ignored if timeout_s is None.
+            oom_retry (bool, optional): Whether to retry if CUDA OOM occurs.
+        """
+        try:
+            logger.info(
+                f"Prediction Worker generate text from prompts with kwargs: {kwargs}")
+            return generate(
+                data,
+                self.generator,
+                timeout_s=timeout_s,
+                start_timestamp=start_timestamp,
+                **kwargs,
+            )
+        except torch.cuda.OutOfMemoryError as e:
+            if not oom_retry:
+                raise e
+            else:
+                logger.error(
+                    "[FIXME] Prediction failed due to CUDA OOM, trying again...\n"
+                    f"{traceback.format_exc()}"
+                )
+                data_1, data_2 = data[: len(data) // 2], data[len(data) // 2:]
+                responses_1 = generate(
+                    data_1,
+                    self.generator,
+                    timeout_s=timeout_s,
+                    start_timestamp=start_timestamp,
+                    **kwargs,
+                )
+                responses_2 = generate(
+                    data_2,
+                    self.generator,
+                    timeout_s=timeout_s,
+                    start_timestamp=start_timestamp,
+                    **kwargs,
+                )
+                return responses_1 + responses_2
+
+    def __repr__(self) -> str:
+        return f"{self.__class__.__name__}:{self.llm_config.model_id}"
+
+    def ping(self) -> bool:
+        """Ping the worker."""
+        return True
+    
+class GenericEngine(LLMEngine):
+    base_worker_group = None
+
+    async def launch_engine(
+            self, 
+            scaling_config: ScalingConfig,
+            placement_group: PlacementGroup,
+            scaling_options: dict,
+        ) -> Any:
+        """Load model.
+
+        Args:
+            model_id (str): Hugging Face model ID.
+        """
+
+        config: Args = self.args  # pylint:disable=no-member
+        llm_config = config.model_config
+        runtime_env = llm_config.initialization.runtime_env or {}
+        prediction_worker_cls = PredictionWorker.options(  # pylint:disable=no-member
+            **scaling_options, runtime_env=runtime_env
+        )
+        
+        # Create the prediction workers.
+        logger.info("Creating prediction workers...")
+        worker_group = [
+            prediction_worker_cls.remote(
+                llm_config, scaling_config.num_workers)
+            for i in range(scaling_config.num_workers)
+        ]
+
+        logger.info("Initializing torch_dist process group on workers...")
+        # Initialize torch distributed process group for the workers.
+        local_ranks = await init_torch_dist_process_group_async(
+            worker_group,
+            backend="nccl" if scaling_config.use_gpu else "gloo",
+        )
+
+        # Initialize model on each worker.
+        logger.info(
+            f"Initializing model on workers with local_ranks: {local_ranks}")
+        await asyncio.gather(
+            *[
+                worker.init_model.remote(
+                    local_rank = local_rank,
+                    num_cpus_per_worker=scaling_config.num_cpus_per_worker,
+                    num_gpus_per_worker=scaling_config.num_gpus_per_worker
+                )
+                for worker, local_rank in zip(worker_group, local_ranks)
+                # for worker in worker_group
+            ]
+        )
+
+        self.base_worker_group = worker_group
+        return worker_group
+
+    async def predict(
+            self,
+            prompts: List[Prompt],
+            *,
+            timeout_s: float = 60,
+            start_timestamp: Optional[float] = None,
+            lock: asyncio.Lock,
+        ) -> List[str]:
+        """Generate text for a list of prompts.
+
+        Args:
+            prompts (List[Prompt]): Batch of prompts to generate text from.
+            timeout_s (float, optional): Timeout for the generation. Defaults
+                to 60. Ignored if start_timestamp is None.
+            start_timestamp (Optional[float], optional): Timestamp of when the
+                batch was created. Defaults to None. If set, will early stop
+                the generation.
+
+        Returns:
+            A list of generated texts.
+        """
+        def slice_prompts(worker_num: int, worker_index: int, prompts: list[str]):
+            prompts = ray.get(prompts)
+
+            slice_size = len(prompts)//worker_num if len(prompts)//worker_num != 0 else 1
+            if worker_index == worker_num - 1:
+                return prompts[slice_size * worker_index:]
+            else:
+                return prompts[slice_size * worker_index: slice_size * worker_index + slice_size]
+
+        logger.info('LLM Predictor do async predict')
+
+        async with lock:
+            # prediction = (
+            #     await asyncio.gather(
+            #         *[
+            #             worker.generate.remote(
+            #                 slice_prompts(len(self.base_worker_group), index, prompts),
+            #                 # prompts,
+            #                 timeout_s=timeout_s,
+            #                 start_timestamp=start_timestamp,
+            #                 **self.args.model_config.generation.all_generate_kwargs if self.args.model_config.generation else {},  # pylint:disable=no-member
+            #             ) if len(slice_prompts(len(self.base_worker_group), index, prompts)) > 0 else ray.put([])
+
+            #             for index, worker in enumerate(self.base_worker_group)
+            #             # for worker in self.base_worker_group
+            #         ]
+            #     )
+            # )
+        # return [response for responses in prediction for response in responses]
+            prediction = (
+                await asyncio.gather(
+                    *[
+                        worker.generate.remote(
+                            # slice_prompts(len(self.base_worker_group), index, prompts),
+                            prompts,
+                            timeout_s=timeout_s,
+                            start_timestamp=start_timestamp,
+                            **self.args.model_config.generation.all_generate_kwargs if self.args.model_config.generation else {},  # pylint:disable=no-member
+                        )
+
+                        # for index, worker in enumerate(self.base_worker_group)
+                        for worker in self.base_worker_group
+                    ]
+                )
+            )[0]
+
+            return prediction
+        
+    async def check_health(self):
+        if self._new_worker_group_lock.locked():
+            logger.info("Rollover in progress, skipping health check")
+            return
+        if self.pg and self.base_worker_group:
+            dead_actors = []
+            for actor in self.base_worker_group:
+                actor_state = ray.state.actors(actor._ray_actor_id.hex())
+                if actor_state["State"] == "DEAD":
+                    dead_actors.append(actor)
+            if dead_actors:
+                raise RuntimeError(
+                    f"At least one prediction worker is dead. Dead workers: {dead_actors}. "
+                    "Reinitializing worker group."
+                )

--- a/llmserve/backend/llm/engines/vllm/__init__.py
+++ b/llmserve/backend/llm/engines/vllm/__init__.py
@@ -1,0 +1,3 @@
+from .vllm import VllmEngine
+
+__all__ = ["VllmEngine"]

--- a/llmserve/backend/llm/engines/vllm/error_handling.py
+++ b/llmserve/backend/llm/engines/vllm/error_handling.py
@@ -1,0 +1,63 @@
+from abc import ABC, abstractmethod, abstractproperty
+
+class ValidationError(ValueError):
+    status_code = 400
+    pass
+
+class PromptTooLongError(ValidationError):
+    pass
+ 
+class ErrorReason(ABC):
+    @abstractmethod
+    def get_message(self) -> str:
+        raise NotImplementedError
+
+    def __str__(self) -> str:
+        return self.get_message()
+
+    @abstractproperty
+    def exception(self) -> Exception:
+        raise NotImplementedError
+
+    def raise_exception(self) -> Exception:
+        raise self.exception
+
+class InputTooLong(ErrorReason):
+    def __init__(self, num_tokens: int, max_num_tokens: int) -> None:
+        self.num_tokens = num_tokens
+        self.max_num_tokens = max_num_tokens
+
+    def get_message(self) -> str:
+        if self.num_tokens < 0:
+            return f"Input too long. The maximum input length is {self.max_num_tokens} tokens."
+        return f"Input too long. Recieved {self.num_tokens} tokens, but the maximum input length is {self.max_num_tokens} tokens."
+
+    @property
+    def exception(self) -> Exception:
+        return PromptTooLongError(self.get_message())
+    
+class ValidationError(ValueError):
+    status_code = 400
+    pass
+
+
+class TooManyStoppingSequencesError(ValidationError):
+    pass
+
+
+class TooManyStoppingSequences(ErrorReason):
+    def __init__(
+        self, num_stopping_sequences: int, max_num_stopping_sequences: int
+    ) -> None:
+        self.num_stopping_sequences = num_stopping_sequences
+        self.max_num_stopping_sequences = max_num_stopping_sequences
+
+    def get_message(self) -> str:
+        return (
+            f"Too many stopping sequences. Recieved {self.num_stopping_sequences} stopping sequences,"
+            f"but the maximum is {self.max_num_stopping_sequences}. Please reduce the number of provided stopping sequences."
+        )
+
+    @property
+    def exception(self) -> Exception:
+        return TooManyStoppingSequencesError(self.get_message())

--- a/llmserve/backend/llm/engines/vllm/generation.py
+++ b/llmserve/backend/llm/engines/vllm/generation.py
@@ -1,0 +1,27 @@
+
+from enum import Enum
+from typing import Optional
+
+
+class FinishReason(str, Enum):
+    LENGTH = "length"
+    STOP = "stop"
+    ERROR = "error"
+    CANCELLED = "cancelled"
+
+    def __str__(self) -> str:
+        return self.value
+
+    @classmethod
+    def from_vllm_finish_reason(
+        cls, finish_reason: Optional[str]
+    ) -> Optional["FinishReason"]:
+        if finish_reason is None:
+            return None
+        if finish_reason == "stop":
+            return cls.STOP
+        if finish_reason == "length":
+            return cls.LENGTH
+        if finish_reason == "abort":
+            return cls.CANCELLED
+        return cls.STOP

--- a/llmserve/backend/llm/engines/vllm/models.py
+++ b/llmserve/backend/llm/engines/vllm/models.py
@@ -1,0 +1,89 @@
+from typing import Any, Dict, List, Optional, Set, TypeVar, Type
+import os
+from pydantic import BaseModel, validator
+from .error_handling import TooManyStoppingSequences
+from llmserve.backend.server.models import BaseModelExtended
+
+ModelT = TypeVar("ModelT", bound=BaseModel)
+MAX_NUM_STOPPING_SEQUENCES = os.getenv("MAX_NUM_STOPPING_SEQUENCES", 8)
+
+
+class SamplingParams(BaseModelExtended):
+    """
+    Args:
+        max_tokens: The maximum number of tokens to generate. Defaults to inf.
+        temperature: What sampling temperature to use.
+        top_p: An alternative to sampling with temperature, called nucleus sampling.
+        logprobs: Include the log probabilities on the `logprobs` most likely
+            tokens, as well the chosen tokens.
+        stop: Up to 4 sequences where the API will stop generating further tokens.
+            The returned text will not contain the stop sequence. List of strings that stop the generation when they are generated.
+            The returned output will not contain the stop strings.
+        presence_penalty: Number between -2.0 and 2.0.
+            Positive values penalize new tokens based on whether they appear in
+            the text so far, increasing the model's likelihood to talk about
+            new topics. Float that penalizes new tokens based on whether they
+            appear in the generated text so far. Values > 0 encourage the model
+            to use new tokens, while values < 0 encourage the model to repeat
+            tokens.
+        frequency_penalty: Number between -2.0 and 2.0. Positive values penalize
+            new tokens based on their existing frequency in the text so far,
+            decreasing the model's likelihood to repeat the same line verbatim.
+            Float that penalizes new tokens based on their
+            frequency in the generated text so far. Values > 0 encourage the
+            model to use new tokens, while values < 0 encourage the model to
+            repeat tokens.
+        n: How many completions to generate for each prompt.
+        best_of: Generates `best_of` completions server-side and returns the "best".
+        ?logit_bias: Modify the likelihood of specified tokens appearing in
+            the completion.
+    """
+
+    _ignored_fields: Set[str] = set()
+
+    max_tokens: Optional[int] = 128
+    temperature: Optional[float] = None
+    top_p: Optional[float] = None
+    n: int = 1
+    logprobs: Optional[int] = None
+    logit_bias: Optional[Dict[str, float]] = None
+    stop: Optional[List[str]] = None
+    presence_penalty: Optional[float] = None
+    frequency_penalty: Optional[float] = None
+    best_of: int = 1
+
+    def dict(self, **kwargs):
+        if kwargs.get("exclude", None) is None:
+            kwargs["exclude"] = self._ignored_fields
+        return super().dict(**kwargs)
+
+    @validator("stop", always=True)
+    def validate_stopping_sequences(cls, values):  # pylint: disable=no-self-argument
+        if not values:
+            return values
+
+        unique_val = sorted(list(set(values)))
+
+        if len(unique_val) > MAX_NUM_STOPPING_SEQUENCES:
+            TooManyStoppingSequences(
+                len(unique_val), MAX_NUM_STOPPING_SEQUENCES
+            ).raise_exception()
+
+        return unique_val
+
+    @classmethod
+    def merge_generation_params(
+        cls: Type[ModelT], prompt: Any, kwargs: dict
+    ) -> ModelT:
+        return cls.parse_obj(kwargs)
+
+
+class VLLMSamplingParams(SamplingParams):
+    """
+    Args:
+        top_k: The number of highest probability vocabulary tokens to keep for top-k-filtering.
+    """
+
+    _ignored_fields = {"best_of", "n", "logit_bias", "logprobs"}
+
+    top_k: Optional[int] = None

--- a/llmserve/backend/llm/engines/vllm/vllm.py
+++ b/llmserve/backend/llm/engines/vllm/vllm.py
@@ -1,0 +1,214 @@
+
+from .._base import LLMEngine
+import asyncio
+import torch
+import gc
+from typing import List, Optional, Any, Dict, List, Optional, AsyncIterator
+from ray.air import ScalingConfig
+from ray.util.placement_group import PlacementGroup
+from llmserve.backend.server.models import Args, Prompt, Response
+from llmserve.backend.logger import get_logger
+from .vllm_compatibility import AsyncLLMEngineRay
+from llmserve.backend.llm.pipelines.utils import construct_prompts
+from .models import VLLMSamplingParams
+from .generation import FinishReason
+import time
+import uuid
+import ray
+from llmserve.backend.server.utils import render_gradio_params
+
+
+from vllm.outputs import RequestOutput
+from vllm.sampling_params import SamplingParams
+
+logger = get_logger(__name__)
+class VllmEngine(LLMEngine):
+    _engine_cls = AsyncLLMEngineRay
+
+    def __init__(
+        self,
+        args: Args,
+
+    ):
+        if not (args.scaling_config.num_gpus_per_worker > 0):
+            raise ValueError("The VLLM Engine Requires > 0 GPUs to run.")
+        self.running = False
+        
+        super().__init__(args = args)
+
+    async def launch_engine(
+        self, 
+        scaling_config: ScalingConfig,
+        placement_group: PlacementGroup,
+        scaling_options: dict,
+    ) -> Any:
+        if self.running:
+            # The engine is already running!
+            logger.info("Skipping engine restart because the engine is already running")
+            return
+
+        config: Args = self.args  # pylint:disable=no-member
+        llm_config = config.model_config
+        runtime_env = llm_config.initialization.runtime_env or {}
+
+        # return AsyncLLMEngine.from_engine_args(engine_args)
+        self.engine = self._engine_cls.from_llm_app(
+                self.args,
+                scaling_options,
+                placement_group,
+                runtime_env,
+            )
+        
+        # warmp up
+        model_task_info = render_gradio_params(llm_config.model_task)
+        warmup_inputs = model_task_info["warmup"] if "warmup" in model_task_info else None
+        warmup_success = False
+        while not warmup_success and llm_config.warmup and warmup_inputs:
+            prompt = [Prompt(prompt=warmup_inputs, use_prompt_format=False)]
+            data_ref = ray.put(prompt)
+            try:
+                logger.info("start to test with single prompt")
+                logger.info(f"warmpup prompt is: {warmup_inputs}")
+                resp = await self.predict(
+                    data_ref,
+                    timeout_s=120,
+                    start_timestamp=None,
+                    lock=None  
+                )
+                logger.info(f"warmpup response is {str(resp)}")
+                assert len(resp) > 0
+                assert all(x.generated_text for x in resp)
+
+                warmup_success = True
+            except torch.cuda.OutOfMemoryError:
+                logger.warning(
+                    f"Warmup failed due to CUDA OOM")
+
+        logger.info(
+            f"Model {llm_config.model_id} succesfully initialized!")
+
+        gc.collect()
+        self.running = True
+
+        return self.engine
+
+    def _parse_sampling_params(
+        self, generate_kwargs: Dict[str, Any]
+    ) -> "SamplingParams":
+        sampling_params = generate_kwargs.copy()
+
+        try:
+            if sampling_params.n != 1:
+                raise ValueError("n>1 is not supported yet in llm-inference")
+            return SamplingParams(
+                n=1,
+                best_of=sampling_params.best_of,
+                presence_penalty=sampling_params.presence_penalty
+                if sampling_params.presence_penalty is not None
+                else 0.0,
+                frequency_penalty=sampling_params.frequency_penalty
+                if sampling_params.frequency_penalty is not None
+                else 0.0,
+                temperature=sampling_params.temperature
+                if sampling_params.temperature is not None
+                else 1.0,
+                top_p=sampling_params.top_p
+                if sampling_params.top_p is not None
+                else 1.0,
+                top_k=sampling_params.top_k
+                if sampling_params.top_k is not None
+                else -1,
+                use_beam_search=False,
+                stop=sampling_params.stop,
+                ignore_eos=False,
+                # vLLM will cancel internally if input+output>max_tokens
+                max_tokens=sampling_params.max_tokens,
+                # or self.engine_config.max_total_tokens,
+                logprobs=sampling_params.logprobs,
+            )
+        except Exception as e:
+            # Wrap the error in ValidationError so the status code
+            # returned to the user is correct.
+            raise SystemError(str(e)) from e
+        
+    async def predict(
+            self,
+            prompts: List[Prompt],
+            *,
+            timeout_s: float = 60,
+            start_timestamp: Optional[float] = None,
+            lock: asyncio.Lock,
+        ) -> List[str]:
+        """Load model.
+
+        Args:
+            model_id (str): Hugging Face model ID.
+        """
+        prompts = ray.get(prompts)
+        prompt_format=(self.args.model_config.generation.prompt_format if self.args.model_config.generation else None)
+        
+        logger.info(f"Get prompt: {prompts}")
+        inputs = construct_prompts(
+            prompts, prompt_format=prompt_format)
+
+        logger.info(f"Get input: {inputs}")
+        if len(inputs) > 1:
+            logger.warn("vllm cannot handle more than 1 prompt with one line engine, try 'LLMEngine' if you want try static batch")
+
+        kwargs = self.args.model_config.generation.all_generate_kwargs if self.args.model_config.generation else {}
+        
+        sampling_params = VLLMSamplingParams.merge_generation_params(
+            dict(), kwargs
+        )
+
+        st = time.monotonic()
+        request_id = str(uuid.uuid4())
+        # Construct a results generator from VLLM
+        results_generator: AsyncIterator[RequestOutput] = self.engine.generate(
+            inputs[0],
+            self._parse_sampling_params(sampling_params),
+            request_id,
+        )
+
+        responses = []
+        try:
+            async for request_output in results_generator:
+                # TODO(pengli): handle more than one output
+                if request_output.finished:
+                    assert (
+                        len(request_output.outputs) == 1
+                    ), "Received more than 1 output from vllm, aborting"
+                    gen_time = time.monotonic() - st
+                    output = request_output.outputs[0]
+                    text_output = output.text
+                    num_text_returned = len(text_output)
+                    num_input_tokens = len(request_output.prompt_token_ids)
+                    finish_reason = FinishReason.from_vllm_finish_reason(
+                        output.finish_reason
+                    )
+
+                    responses.append(
+                        Response(
+                            generated_text=text_output,
+                            num_generated_tokens=1,
+                            num_generated_tokens_batch=1,
+                            num_input_tokens=num_input_tokens,
+                            num_input_tokens_batch=num_input_tokens,
+                            preprocessing_time=None,
+                            postprocessing_time=None,
+                            generation_time=gen_time,
+                        )
+                    )
+            logger.info(
+                f"Request {request_id} finished ({finish_reason}). "
+                f"Total time: {(gen_time)}s, "
+            )
+        finally:
+            # Ensure that we cancel on the engine once we have exited the streaming
+            # phase
+            self.engine._abort(request_id)
+
+        return responses
+    
+    async def check_health(self):
+        logger.info("not implements yet...")

--- a/llmserve/backend/llm/engines/vllm/vllm_compatibility.py
+++ b/llmserve/backend/llm/engines/vllm/vllm_compatibility.py
@@ -1,0 +1,150 @@
+import logging
+import time
+from typing import TYPE_CHECKING, Any, List, Optional, Tuple, Type, Union
+
+import ray
+from ray.util.placement_group import PlacementGroup
+from transformers.dynamic_module_utils import init_hf_modules
+from llmserve.backend.server.models import Args
+
+
+from vllm.config import CacheConfig as VllmCacheConfig
+from vllm.config import ModelConfig as VllmModelConfig
+from vllm.config import ParallelConfig as VllmParallelConfig
+from vllm.config import SchedulerConfig as VllmSchedulerConfig
+from vllm.engine.arg_utils import AsyncEngineArgs
+from vllm.engine.async_llm_engine import AsyncLLMEngine, AsyncStream, _AsyncLLMEngine
+
+from .error_handling import InputTooLong
+
+if TYPE_CHECKING:
+    from vllm.sampling_params import SamplingParams
+
+
+# This has to be ran at module level to fix serialization issues
+# with remote HF Transformers code.
+init_hf_modules()
+
+logger = logging.getLogger(__name__)
+
+VllmConfigs = Tuple[
+    VllmCacheConfig, VllmModelConfig, VllmParallelConfig, VllmSchedulerConfig
+]
+
+
+class LLMEngineRay(_AsyncLLMEngine):
+    def __init__(self, *args, runtime_env: dict, **kwargs):
+        self.runtime_env = runtime_env
+        super().__init__(*args, **kwargs)
+
+    def _init_workers_ray(self, placement_group: "PlacementGroup", **ray_remote_kwargs):
+        ray_remote_kwargs.setdefault("runtime_env", self.runtime_env)
+        return super()._init_workers_ray(placement_group, **ray_remote_kwargs)
+
+    async def _encode_request_async(
+        self,
+        request_id: str,
+        prompt: Optional[str],
+        prompt_token_ids: Optional[List[int]] = None,
+        tokenizer: Any = None,
+    ) -> Union[List[int], Exception]:
+        if prompt_token_ids is None:
+            assert prompt is not None
+            if tokenizer is None:
+                tokenizer = self.tokenizer
+            prompt_token_ids = tokenizer.encode(prompt)
+        num_input_tokens = len(prompt_token_ids)
+        if hasattr(self.model_config, "get_max_model_len"):
+            max_input_length = self.model_config.get_max_model_len()
+        else:
+            max_input_length = self.model_config.max_model_len
+        if num_input_tokens > max_input_length:
+            logger.info(
+                f"Task {request_id} is over the max input length ({num_input_tokens}/{max_input_length})."
+            )
+            raise InputTooLong(num_input_tokens, max_input_length).exception
+        return prompt_token_ids
+
+
+def _get_vllm_engine_config(args: Args) -> Tuple[AsyncEngineArgs, VllmConfigs]:
+    # Generate engine arguements and engine configs
+
+    async_engine_args = AsyncEngineArgs(
+        # This is the local path on disk, or the hf model id
+        # If it is the hf_model_id, vllm automatically downloads the correct model.
+        **dict(
+            model=args.model_config.actual_hf_model_id,
+            worker_use_ray=True,
+            engine_use_ray=False,
+            tensor_parallel_size=args.scaling_config.num_workers,
+            max_model_len=args.model_config.max_input_words,
+            disable_log_stats=False,
+            max_log_len=64,
+            **args.model_config.initialization.initializer.get_initializer_kwargs(),
+        )
+    )
+    configs = async_engine_args.create_engine_configs()
+    return async_engine_args, configs
+
+
+class AsyncLLMEngineRay(AsyncLLMEngine):
+    _engine_class: Type[_AsyncLLMEngine] = LLMEngineRay
+
+    async def add_request(
+        self,
+        request_id: str,
+        prompt: Optional[str],
+        sampling_params: "SamplingParams",
+        prompt_token_ids: Optional[List[int]] = None,
+        arrival_time: Optional[float] = None,
+        **kwargs,
+    ) -> AsyncStream:
+        if arrival_time is None:
+            arrival_time = time.time()
+        prompt_token_ids = await self.engine._encode_request_async(
+            request_id, prompt, prompt_token_ids
+        )
+        return await super().add_request(
+            request_id=request_id,
+            prompt=prompt,
+            sampling_params=sampling_params,
+            prompt_token_ids=prompt_token_ids,
+            arrival_time=arrival_time,
+            **kwargs,
+        )
+
+    @classmethod
+    def from_llm_app(
+        cls,
+        args: Args,
+        scaling_options: dict,
+        placement_group: PlacementGroup,
+        runtime_env: dict,
+    ) -> "AsyncLLMEngineRay":
+        """Creates an async LLM engine from the engine arguments."""
+
+        # When using gpu special type, vllm does a type check that requires
+        # torch to have access to CUDA devices. We use a remote task
+        # with `num_gpus` set here, so the type check happens in an environment
+        # with `CUDA_VISIBLE_DEVICES` set.
+        engine_args, engine_configs = ray.get(
+            ray.remote(_get_vllm_engine_config)
+            .options(**scaling_options)
+            .remote(args)
+        )
+        # Create the async LLM engine.
+        engine = cls(
+            engine_args.worker_use_ray,
+            engine_args.engine_use_ray,
+            *engine_configs,
+            None,
+            placement_group,
+            runtime_env=runtime_env,
+            log_requests=not engine_args.disable_log_requests,
+            log_stats=not engine_args.disable_log_stats,
+            max_log_len=engine_args.max_log_len,
+            start_engine_loop=True,
+        )
+        
+        return engine
+    

--- a/llmserve/backend/llm/predictor.py
+++ b/llmserve/backend/llm/predictor.py
@@ -1,281 +1,21 @@
 import asyncio
 import gc
-import os
-import traceback
 from typing import List, Optional
 
 import ray
 import ray.util
-import torch
-import torch.backends.cuda
 from ray.air import ScalingConfig
-from ray.air.util.torch_dist import TorchDistributedWorker
 from ray.util.scheduling_strategies import PlacementGroupSchedulingStrategy
 
-from llmserve.backend.llm.initializers import get_initializer_cls_by_name
-from llmserve.backend.llm.pipelines import get_pipeline_cls_by_name
-from llmserve.backend.llm.pipelines._base import BasePipeline
+from llmserve.backend.llm.engines import get_engine_cls_by_name
 from llmserve.backend.llm.utils import (
-    init_torch_dist_process_group_async,
     initialize_node,
-    timeit,
-    get_max_token_size,
 )
 from llmserve.backend.logger import get_logger
-from llmserve.backend.server.models import Args, LLMConfig, Prompt, Response
-from llmserve.backend.server.utils import render_gradio_params
-
-WARMUP_PROMPT = "Write a short story."
+from llmserve.backend.server.models import Args, Prompt
 
 initialize_node_remote = ray.remote(initialize_node)
-
 logger = get_logger(__name__)
-
-
-@timeit
-def init_model(
-    llm_config: LLMConfig,
-    world_size: int,
-    local_rank: int,
-    max_batch_size: Optional[int] = None,
-):
-    """Initialize the model.
-
-    Args:
-        llm_config (LLM): LLM configuration.
-        world_size (int): Number of GPUs.
-        local_rank (int): Local rank of the current GPU.
-        max_batch_size (Optional[int], optional): Maximum batch size. Defaults to None.
-    """
-    logger.info(
-        f"Initializing model {llm_config.model_id} with local_rank: {local_rank}")
-
-    # Lazy import so that the new cache location is used
-    torch.backends.cuda.matmul.allow_tf32 = True
-    if torch.cuda.is_available():
-        device = torch.device(f"cuda:{local_rank}")
-        # device = torch.device("cuda")
-    else:
-        device = torch.device("cpu")
-
-    initializer_name = llm_config.initialization.initializer
-    if not isinstance(initializer_name, str):
-        initializer_name = initializer_name.type
-
-    logger.info(f"Initializer name is {initializer_name} on device {device}")
-    initializer = get_initializer_cls_by_name(initializer_name)(
-        device=device,
-        world_size=world_size,
-        **llm_config.initialization.initializer.get_initializer_kwargs(),
-    )
-
-    pipeline_name = llm_config.initialization.pipeline
-    additional_kwargs = dict(
-        task=llm_config.model_task,
-    )
-    logger.info(f"Pipeline name is {pipeline_name} on device {device}")
-    pipeline = get_pipeline_cls_by_name(pipeline_name).from_initializer(
-        initializer,
-        llm_config.actual_hf_model_id,
-        prompt_format=(
-            llm_config.generation.prompt_format if llm_config.generation else None),
-        device=device,
-        **additional_kwargs
-    )
-
-    # Warmup
-    # For DS w/ kernel inject, first batch the model gets MUST be of maximum batch size,
-    # otherwise subsequent batches with more entries than the first batch
-    # will raise CUDA errors if use_kernel=True.
-    batch_size = max_batch_size or 1
-
-    logger.info(f"Model {llm_config.model_id} batch_size is {batch_size}")
-    model_task_info = render_gradio_params(llm_config.model_task)
-    warmup_inputs = model_task_info["warmup"] if "warmup" in model_task_info else None
-
-    if llm_config.warmup and warmup_inputs:
-        prowarmup_inputs_max = Prompt(prompt=warmup_inputs * (
-            int(get_max_token_size(llm_config) / (len(warmup_inputs.split()) + 1))
-        ), use_prompt_format=False)
-
-        logger.info(
-            f"Model {llm_config.model_id} is warming up, input is {warmup_inputs}...")
-        if llm_config.generation:
-            generate_kwargs = llm_config.generation.all_generate_kwargs.copy()
-            if "max_new_tokens" in generate_kwargs:
-                generate_kwargs["min_new_tokens"] = generate_kwargs["max_new_tokens"]
-        else:
-            generate_kwargs = {}
-
-    warmup_success = False
-    while not warmup_success and llm_config.warmup and warmup_inputs:
-        try:
-            logger.info("start to test with single prompt")
-            logger.info(f"warmpup prompt is: {warmup_inputs}")
-            resp = generate(
-                [Prompt(prompt=warmup_inputs, use_prompt_format=False)],
-                pipeline,
-                **generate_kwargs,
-            )
-            logger.info(f"warmpup response is {str(resp)}")
-            assert len(resp) > 0
-            assert all(x.generated_text for x in resp)
-
-            logger.info("start to test with max batch prompts, try to find a suitable batch size")
-            assert batch_size > 0
-            resp_batch = generate(
-                [prowarmup_inputs_max] * batch_size,
-                pipeline,
-                **generate_kwargs,
-            )
-            logger.info(str(resp_batch))
-            assert len(resp_batch) == batch_size
-            assert all(x.generated_text for x in resp_batch)
-
-            warmup_success = True
-        except torch.cuda.OutOfMemoryError:
-            batch_size -= 2
-            logger.warning(
-                f"Warmup failed due to CUDA OOM, reducing batch size to {batch_size}")
-
-    logger.info(
-        f"Model {llm_config.model_id} succesfully initialized, final batch size {batch_size}!")
-
-    gc.collect()
-
-    return pipeline
-
-
-@timeit
-def generate(
-    prompts: List[Prompt], pipeline: BasePipeline, **generate_kwargs
-) -> List[Response]:
-    """Generate predictions using a Pipeline.
-
-    Args:
-        prompts (List[Prompt]): List of prompts.
-        pipeline (BasePipeline): Pipeline to use.
-        **generate_kwargs: Keyword arguments to pass to the pipeline's `generate` method.
-    """
-    logger.info(f"Call pipeline with generate_kwargs: {generate_kwargs}")
-    outputs = pipeline(
-        prompts,
-        **generate_kwargs,
-    )
-    return outputs
-
-import logging
-@ray.remote
-class PredictionWorker(TorchDistributedWorker):
-    """A PredictionWorker is a Ray remote actor that runs a single shard of a DeepSpeed job.
-
-    Multiple PredictionWorkers of the same WorkerGroup will form a PyTorch DDP process
-    group and work together under the orchestration of DeepSpeed.
-
-    Args:
-        llm_config (LLM): LLM configuration.
-        world_size (int): Number of GPUs.
-    """
-
-    def __init__(self, llm_config: LLMConfig, world_size: int):
-        self.llm_config = llm_config
-        self.world_size = world_size
-
-    def init_model(
-        self,
-        local_rank: int,
-        num_cpus_per_worker: int = 1,
-        num_gpus_per_worker: int = 0,
-    ):
-        """Initialize model for inference.
-
-        Args:
-            local_rank (int): Local rank of the current GPU.
-            num_cpus_per_worker (int, optional): Number of CPUs to use per worker. Defaults to 1.
-        """
-        
-        # Recreate the logger to make sure it takes precedence over
-        # other logger configurations.
-        # get_logger(__name__, force=True)
-
-        # for DDP, comment now, still consider if ddp is a case
-        # rank = torch.distributed.get_rank()
-        # logger.info(rank)
-
-        logger.info(
-            f"num_gpus_per_worker: {num_gpus_per_worker}, num_cpus_per_worker: {num_cpus_per_worker}")
-        os.environ["OMP_NUM_THREADS"] = str(int(num_cpus_per_worker))
-
-        logger.info("Prediction Worker calling init model")
-        self.generator = init_model(
-            self.llm_config,
-            self.world_size,
-            local_rank,
-            max_batch_size=(
-                self.llm_config.generation.max_batch_size if self.llm_config.generation else None),
-        )
-
-    def generate(
-        self,
-        data: List[Prompt],
-        *,
-        timeout_s: Optional[float] = None,
-        start_timestamp: Optional[float] = None,
-        oom_retry: bool = True,
-        **kwargs,
-    ) -> List[str]:
-        """Generate text from prompts.
-
-        Args:
-            data (List[Prompt]): Batch of prompts.
-            timeout_s (Optional[float], optional): Timeout for the generation.
-                Ignored if start_timestamp is None.
-            start_timestamp (Optional[float], optional): Timestamp of when the
-                batch was created. Defaults to None. If set, will early stop
-                the generation. Ignored if timeout_s is None.
-            oom_retry (bool, optional): Whether to retry if CUDA OOM occurs.
-        """
-        try:
-            logger.info(
-                f"Prediction Worker generate text from prompts with kwargs: {kwargs}")
-            return generate(
-                data,
-                self.generator,
-                timeout_s=timeout_s,
-                start_timestamp=start_timestamp,
-                **kwargs,
-            )
-        except torch.cuda.OutOfMemoryError as e:
-            if not oom_retry:
-                raise e
-            else:
-                logger.error(
-                    "[FIXME] Prediction failed due to CUDA OOM, trying again...\n"
-                    f"{traceback.format_exc()}"
-                )
-                data_1, data_2 = data[: len(data) // 2], data[len(data) // 2:]
-                responses_1 = generate(
-                    data_1,
-                    self.generator,
-                    timeout_s=timeout_s,
-                    start_timestamp=start_timestamp,
-                    **kwargs,
-                )
-                responses_2 = generate(
-                    data_2,
-                    self.generator,
-                    timeout_s=timeout_s,
-                    start_timestamp=start_timestamp,
-                    **kwargs,
-                )
-                return responses_1 + responses_2
-
-    def __repr__(self) -> str:
-        return f"{self.__class__.__name__}:{self.llm_config.model_id}"
-
-    def ping(self) -> bool:
-        """Ping the worker."""
-        return True
 
 
 class LLMPredictor:
@@ -287,6 +27,7 @@ class LLMPredictor:
         self.new_worker_group = None
         self._base_worker_group_lock = asyncio.Lock()
         self._new_worker_group_lock = asyncio.Lock()
+
 
     async def rollover(self, scaling_config: ScalingConfig, pg_timeout_s: float = 600):
         """Roll over to a new worker group.
@@ -303,6 +44,22 @@ class LLMPredictor:
             return
         async with self._new_worker_group_lock:
             logger.info(f"Initializing new worker group {scaling_config}")
+
+            # init engine here
+            config: Args = self.args  # pylint:disable=no-member
+            llm_config = config.model_config
+            initializer_name = llm_config.initialization.initializer
+            if not isinstance(initializer_name, str):
+                initializer_name = initializer_name.type
+            
+            engine_name = ("vllm" if initializer_name == "Vllm" else "generic")
+                
+            logger.info(f"Engine name is {engine_name}")
+            self.engine = get_engine_cls_by_name(engine_name)(
+                args = self.args
+            )
+
+
             self.new_worker_group = await self._create_worker_group(
                 scaling_config, pg_timeout_s=pg_timeout_s
             )
@@ -341,9 +98,9 @@ class LLMPredictor:
         runtime_env = llm_config.initialization.runtime_env or {}
         logger.info("Build Prediction Worker with runtime_env:")
         logger.info(llm_config.initialization.runtime_env)
-        prediction_worker_cls = PredictionWorker.options(  # pylint:disable=no-member
-            **scaling_options, runtime_env=runtime_env
-        )
+        # prediction_worker_cls = PredictionWorker.options(  # pylint:disable=no-member
+        #     **scaling_options, runtime_env=runtime_env
+        # )
         initialize_node_remote_pg = initialize_node_remote.options(
             **scaling_options, runtime_env=runtime_env
         )
@@ -364,36 +121,37 @@ class LLMPredictor:
         )
 
         # Create the prediction workers.
-        logger.info("Creating prediction workers...")
-        worker_group = [
-            prediction_worker_cls.remote(
-                llm_config, scaling_config.num_workers)
-            for i in range(scaling_config.num_workers)
-        ]
+        # logger.info("Creating prediction workers...")
+        # worker_group = [
+        #     prediction_worker_cls.remote(
+        #         llm_config, scaling_config.num_workers)
+        #     for i in range(scaling_config.num_workers)
+        # ]
 
-        logger.info("Initializing torch_dist process group on workers...")
-        # Initialize torch distributed process group for the workers.
-        local_ranks = await init_torch_dist_process_group_async(
-            worker_group,
-            backend="nccl" if scaling_config.use_gpu else "gloo",
-        )
+        # logger.info("Initializing torch_dist process group on workers...")
+        # # Initialize torch distributed process group for the workers.
+        # local_ranks = await init_torch_dist_process_group_async(
+        #     worker_group,
+        #     backend="nccl" if scaling_config.use_gpu else "gloo",
+        # )
 
-        # Initialize model on each worker.
-        logger.info(
-            f"Initializing model on workers with local_ranks: {local_ranks}")
-        await asyncio.gather(
-            *[
-                worker.init_model.remote(
-                    local_rank = local_rank,
-                    num_cpus_per_worker=scaling_config.num_cpus_per_worker,
-                    num_gpus_per_worker=scaling_config.num_gpus_per_worker
-                )
-                for worker, local_rank in zip(worker_group, local_ranks)
-                # for worker in worker_group
-            ]
-        )
+        # # Initialize model on each worker.
+        # logger.info(
+        #     f"Initializing model on workers with local_ranks: {local_ranks}")
+        # await asyncio.gather(
+        #     *[
+        #         worker.init_model.remote(
+        #             local_rank = local_rank,
+        #             num_cpus_per_worker=scaling_config.num_cpus_per_worker,
+        #             num_gpus_per_worker=scaling_config.num_gpus_per_worker
+        #         )
+        #         for worker, local_rank in zip(worker_group, local_ranks)
+        #         # for worker in worker_group
+        #     ]
+        # )
 
-        return worker_group
+        engine = await self.engine.launch_engine(scaling_config, self.pg, scaling_options)
+        return engine
 
     async def _predict_async(
         self,
@@ -415,51 +173,9 @@ class LLMPredictor:
         Returns:
             A list of generated texts.
         """
-        def slice_prompts(worker_num: int, worker_index: int, prompts: list[str]):
-            prompts = ray.get(prompts)
+        prediction = await self.engine.predict(prompts, timeout_s=timeout_s, start_timestamp=start_timestamp, lock = self._base_worker_group_lock)
+        return prediction
 
-            slice_size = len(prompts)//worker_num if len(prompts)//worker_num != 0 else 1
-            if worker_index == worker_num - 1:
-                return prompts[slice_size * worker_index:]
-            else:
-                return prompts[slice_size * worker_index: slice_size * worker_index + slice_size]
-
-        logger.info('LLM Predictor do async predict')
-
-        async with self._base_worker_group_lock:
-            # prediction = (
-            #     await asyncio.gather(
-            #         *[
-            #             worker.generate.remote(
-            #                 slice_prompts(len(self.base_worker_group), index, prompts),
-            #                 # prompts,
-            #                 timeout_s=timeout_s,
-            #                 start_timestamp=start_timestamp,
-            #                 **self.args.model_config.generation.all_generate_kwargs if self.args.model_config.generation else {},  # pylint:disable=no-member
-            #             ) if len(slice_prompts(len(self.base_worker_group), index, prompts)) > 0 else ray.put([])
-
-            #             for index, worker in enumerate(self.base_worker_group)
-            #             # for worker in self.base_worker_group
-            #         ]
-            #     )
-            # )
-        # return [response for responses in prediction for response in responses]
-            prediction = (
-                await asyncio.gather(
-                    *[
-                        worker.generate.remote(
-                            # slice_prompts(len(self.base_worker_group), index, prompts),
-                            prompts,
-                            timeout_s=timeout_s,
-                            start_timestamp=start_timestamp,
-                            **self.args.model_config.generation.all_generate_kwargs if self.args.model_config.generation else {},  # pylint:disable=no-member
-                        )
-
-                        # for index, worker in enumerate(self.base_worker_group)
-                        for worker in self.base_worker_group
-                    ]
-                )
-            )[0]
-
-            return prediction
-
+    # Called by Serve to check the replica's health.
+    async def check_health(self):
+        self.engine.check_health()

--- a/llmserve/backend/server/app.py
+++ b/llmserve/backend/server/app.py
@@ -300,23 +300,6 @@ class LLMDeployment(LLMPredictor):
             return [prediction]
         return prediction[: len(prompts)]
 
-    # Called by Serve to check the replica's health.
-    async def check_health(self):
-        if self._new_worker_group_lock.locked():
-            logger.info("Rollover in progress, skipping health check")
-            return
-        if self.pg and self.base_worker_group:
-            dead_actors = []
-            for actor in self.base_worker_group:
-                actor_state = ray.state.actors(actor._ray_actor_id.hex())
-                if actor_state["State"] == "DEAD":
-                    dead_actors.append(actor)
-            if dead_actors:
-                raise RuntimeError(
-                    f"At least one prediction worker is dead. Dead workers: {dead_actors}. "
-                    "Reinitializing worker group."
-                )
-
     def __repr__(self) -> str:
         return f"{self.__class__.__name__}:{self.args.model_config.model_id}"
 


### PR DESCRIPTION
This is a more complicated pr...
The previously implements has a issue: cannot run with `tensor_parallel_size` > 1, means cannot launch with vllm with multiple GPUs. 
The reason is `vllm` itself leverage `ray` to handle multiple GPUs internal, that's means `vllm` addressed above `ray`,
in contrast, `llm-inference` put ray above inference implements(vllm, deepspeed, pytorch .ect)

That's caused the issue(cannot run with more than one GPU, remember?)