### PR TITLE
Refactor streaming

### DIFF
--- a/llmserve/backend/llm/engines/_base.py
+++ b/llmserve/backend/llm/engines/_base.py
@@ -6,11 +6,11 @@ from llmserve.backend.server.models import Prompt
 
 from llmserve.backend.logger import get_logger
 
-from typing import List, Optional
+from typing import List, Optional, Iterator
 from ray.air import ScalingConfig
 
 from llmserve.backend.logger import get_logger
-from llmserve.backend.server.models import Args, Prompt
+from llmserve.backend.server.models import Args, Prompt, Response
 import asyncio
 from typing import Union, AsyncGenerator, Generator
 
@@ -67,5 +67,12 @@ class LLMEngine(ABC):
         pass
     
     @abstractmethod
-    def stream_generate_texts(self, prompt: Union[Prompt, List[Prompt]]) -> Generator[str, None, None]:
+    async def stream(
+        self,
+        prompts: List[Prompt],
+        *,
+        timeout_s: float = 60,
+        start_timestamp: Optional[float] = None,
+        lock: asyncio.Lock,
+    ) -> Iterator[List[Response]]:
         pass

--- a/llmserve/backend/llm/engines/vllm/vllm.py
+++ b/llmserve/backend/llm/engines/vllm/vllm.py
@@ -3,7 +3,7 @@ from .._base import LLMEngine
 import asyncio
 import torch
 import gc
-from typing import List, Optional, Any, Dict, List, Optional, AsyncIterator
+from typing import List, Optional, Any, Dict, List, Optional, AsyncIterator, Iterator
 from ray.air import ScalingConfig
 from ray.util.placement_group import PlacementGroup
 from llmserve.backend.server.models import Args, Prompt, Response
@@ -226,3 +226,13 @@ class VllmEngine(LLMEngine):
     
     async def check_health(self):
         logger.info("not implements yet...")
+
+    async def stream(
+        self,
+        prompts: List[Prompt],
+        *,
+        timeout_s: float = 60,
+        start_timestamp: Optional[float] = None,
+        lock: asyncio.Lock,
+    ) -> Iterator[List[Response]]:
+        pass

--- a/llmserve/backend/llm/pipelines/_base.py
+++ b/llmserve/backend/llm/pipelines/_base.py
@@ -340,15 +340,10 @@ class BasePipeline(ABC):
 
         return preprocess_params, forward_params, postprocess_params
 
-    @abstractmethod
-    def streamGenerate(self, prompt: Union[Prompt, List[Prompt]], **generate_kwargs) -> Generator[str, None, None]:
-        pass
-
 class StreamingPipeline(BasePipeline):
     def stream(
         self,
-        inputs: List[str],
-        queue: Queue,
+        inputs: List[Union[str, Prompt]],
         **kwargs,
     ) -> Iterator[List[Response]]:
         raise NotImplementedError()

--- a/llmserve/backend/llm/pipelines/default_pipeline.py
+++ b/llmserve/backend/llm/pipelines/default_pipeline.py
@@ -2,17 +2,17 @@ import time
 from typing import List, Optional, Union, TYPE_CHECKING
 
 import torch
-from transformers import PreTrainedModel, PreTrainedTokenizer
+from transformers import PreTrainedModel, PreTrainedTokenizer, AutoTokenizer
 
 from llmserve.backend.logger import get_logger
 from llmserve.backend.server.models import Prompt, Response
 import json
 
-from ._base import BasePipeline
+from ._base import StreamingPipeline
 from .processors import StopOnTokens
 from .utils import construct_prompts, truncate_to_first_stop_token
 
-from typing import AsyncGenerator, Generator
+from typing import AsyncGenerator, Generator, Iterator
 import asyncio
 from transformers import TextIteratorStreamer
 from threading import Thread
@@ -20,8 +20,63 @@ from queue import Empty
 
 logger = get_logger(__name__)
 
+class BatchTextIteratorStreamer(TextIteratorStreamer):
+    def __init__(self, batch_size:int, tokenizer: "AutoTokenizer", skip_prompt: bool = False, timeout: Optional[float] = None, **decode_kwargs):
+        super().__init__(tokenizer, skip_prompt, timeout, **decode_kwargs)
+        self.batch_size = batch_size
+        self.token_cache = [[] for _ in range(batch_size)]
+        self.print_len = [0 for _ in range(batch_size)]
+        self.generate_exception = None
 
-class DefaultPipeline(BasePipeline):
+    def put(self, value):
+        if len(value.shape) != 2:
+            value = torch.reshape(value, (self.batch_size, value.shape[0] // self.batch_size))
+
+        if self.skip_prompt and self.next_tokens_are_prompt:
+            self.next_tokens_are_prompt = False
+            return
+
+        printable_texts = list()
+        for idx in range(self.batch_size):
+            self.token_cache[idx].extend(value[idx].tolist())
+            text = self.tokenizer.decode(self.token_cache[idx], **self.decode_kwargs)
+
+            if text.endswith("\n"):
+                printable_text = text[self.print_len[idx] :]
+                self.token_cache[idx] = []
+                self.print_len[idx] = 0
+                # If the last token is a CJK character, we print the characters.
+            elif len(text) > 0 and self._is_chinese_char(ord(text[-1])):
+                printable_text = text[self.print_len[idx] :]
+                self.print_len[idx] += len(printable_text)
+            else:
+                printable_text = text[self.print_len[idx] : text.rfind(" ") + 1]
+                self.print_len[idx] += len(printable_text)
+            printable_texts.append(printable_text)
+
+        self.on_finalized_text(printable_texts)
+
+    def end(self):
+        printable_texts = list()
+        for idx in range(self.batch_size):
+            if len(self.token_cache[idx]) > 0:
+                text = self.tokenizer.decode(self.token_cache[idx], **self.decode_kwargs)
+                printable_text = text[self.print_len[idx] :]
+                self.token_cache[idx] = []
+                self.print_len[idx] = 0
+            else:
+                printable_text = ""
+            printable_texts.append(printable_text)
+
+        self.next_tokens_are_prompt = True
+        self.on_finalized_text(printable_texts, stream_end=True)
+
+    def on_finalized_text(self, texts: List[str], stream_end: bool = False):
+        self.text_queue.put(texts, timeout=self.timeout)
+        if stream_end:
+            self.text_queue.put(self.stop_signal, timeout=self.timeout)
+
+class DefaultPipeline(StreamingPipeline):
     """Default text generation pipeline.
 
     Args:
@@ -99,59 +154,55 @@ class DefaultPipeline(BasePipeline):
         preprocessing_time = model_inputs["preprocessing_time"]
         logger.info(
             f"Call model.generate with generate_kwargs: {generate_kwargs}")
-        generated_sequence = self.model.generate(
-            **{
-                **inputs,
-                **generate_kwargs,
-            }
-        )
-        et = time.monotonic() - st
-        return {
-            "inputs": inputs,
-            "generated_sequence": generated_sequence,
-            "instruction_text": instruction_text,
-            "prompt_text": prompt_text,
-            "preprocessing_time": preprocessing_time,
-            "generation_time": et,
-            "generate_kwargs": generate_kwargs,
-        }
+        
+        batch_size = inputs["input_ids"].size(dim=0)
+        logger.info(f"batch size is: {batch_size}")
+        streamer = BatchTextIteratorStreamer(batch_size=batch_size, tokenizer= self.tokenizer,
+                                        # timeout=0,
+                                        skip_prompt=True,
+                                        skip_special_tokens=True)
+            
+        generation_kwargs = dict(inputs, streamer=streamer, **generate_kwargs)
+        thread = Thread(target=self.model.generate, kwargs=generation_kwargs)
+        thread.start()
+        while True:
+            try:
+                for token in streamer:
+                    et = time.monotonic() - st
+                    st = et
+                    if token:
+                        yield {
+                            "inputs": inputs,
+                            "generated_sequence": [token],
+                            "instruction_text": instruction_text,
+                            "prompt_text": prompt_text,
+                            "preprocessing_time": preprocessing_time,
+                            "generation_time": et,
+                            "generate_kwargs": generate_kwargs,
+                        }
+                break
+            except Empty:
+                asyncio.sleep(0.001)
 
     def postprocess(self, model_outputs, **postprocess_kwargs) -> List[Response]:
         st = time.monotonic()
         tokens = model_outputs["generated_sequence"]
+        tokens = tokens[0]
         input_ids = model_outputs["inputs"]["input_ids"]
-        token_stopper = next(
-            (
-                x
-                for x in model_outputs["generate_kwargs"].get("stopping_criteria", [])
-                if isinstance(x, StopOnTokens)
-            ),
-            None,
-        )
+
         decoded: List[Response] = []
         num_generated_tokens_batch = 0
         num_input_tokens_batch = 0
         for token_unwrapped, inputs_unwrapped in zip(tokens, input_ids):
-            logger.info(
-                f"Unprocessed generated tokens: '{self.tokenizer.decode(token_unwrapped, skip_special_tokens=False).encode('unicode_escape').decode('utf-8')}'"
-            )
-            tokens = token_unwrapped[len(inputs_unwrapped):]
-            if token_stopper:
-                tokens = truncate_to_first_stop_token(
-                    tokens, token_stopper.stopping_sequences
-                )
-            text = (
-                self.tokenizer.decode(tokens, skip_special_tokens=True)
-                .replace("\u200b", "")
-                .strip()
-            )
+            tokens = token_unwrapped
+
             for i in range(len(inputs_unwrapped)):
                 if inputs_unwrapped[i] != self.tokenizer.pad_token_id:
                     break
             num_input_tokens = len(inputs_unwrapped[i:])
             num_generated_tokens = len(tokens)
             response = Response(
-                generated_text=text,
+                generated_text=tokens,
                 num_generated_tokens=num_generated_tokens,
                 num_input_tokens=num_input_tokens,
             )
@@ -167,41 +218,36 @@ class DefaultPipeline(BasePipeline):
             response.postprocessing_time = et
         return decoded
 
-    def streamGenerate(self, prompt: Union[Prompt, List[Prompt]], **generate_kwargs) -> Generator[str, None, None]:
-        logger.info(f"DefaultPipeline.streamGenerate with generate_kwargs: {generate_kwargs}")
-        # timeout=0  will dramatic slow down the speed of generator, the root caused still unknow
-        streamer = TextIteratorStreamer(self.tokenizer,
-                                        # timeout=0,
-                                        skip_prompt=True,
-                                        skip_special_tokens=True)
-        prompt_inputs = []
-        if isinstance(prompt, Prompt):
-            prompt_inputs = [prompt.prompt]
-        elif isinstance(prompt, list):
-            prompt_inputs = [p.prompt for p in prompt]
-            
-        logger.info(f"DefaultPipeline.streamGenerate with prompt_inputs: {prompt_inputs}")
-        input_ids = self.tokenizer(prompt_inputs, return_tensors="pt")
-        # input_ids = self.tokenizer([prompt], return_tensors="pt")
-        max_new_tokens = 256
-        if generate_kwargs["max_new_tokens"]:
-            max_new_tokens = generate_kwargs["max_new_tokens"]
-        generation_kwargs = dict(input_ids, streamer=streamer, max_new_tokens=max_new_tokens)
-        thread = Thread(target=self.model.generate, kwargs=generation_kwargs)
-        thread.start()
-        while True:
-            try:
-                for token in streamer:
-                    logger.info(f'DefaultPipeline.streamGenerate -> Yield -> "{token}" -> "{type(token)}"')
-                    yield token
-                break
-            except Empty:
-                asyncio.sleep(0.001)
-        
-        # start = 0
-        # while True:
-        #     val = prompt + str(start)
-        #     logger.info(f"PredictionWorker.worker_stream_generate_texts -> yield -> {val}")
-        #     yield val
-        #     start += 1
-        #     asyncio.sleep(1)
+    @torch.inference_mode()
+    def stream(
+        self,
+        inputs: List[Union[str, Prompt]],
+        **kwargs,
+    ) -> Iterator[List[Response]]:
+        (
+            preprocess_params,
+            forward_params,
+            postprocess_params,
+        ) = self._sanitize_parameters(**kwargs)
+        model_inputs = self.preprocess(inputs, **preprocess_params)
+        model_inputs = self._ensure_tensor_on_device(model_inputs, device=self.device)
+        forward_params = self._add_default_generate_kwargs(forward_params, model_inputs)
+
+        logger.info(
+            f"Forward params: {forward_params}, batch size: {len(inputs)} model_inputs {model_inputs}"
+        )
+        for batch in self.forward(model_inputs, **forward_params):
+            yield self.postprocess(batch)
+
+    def __call__(
+        self,
+        inputs: List[Union[str, Prompt]],
+        **kwargs,
+    ) -> List[Response]:
+        streams = [list() for _ in range(len(inputs))]
+        for batch_response in self.stream(inputs, **kwargs):
+            for i, response in enumerate(batch_response):
+                streams[i].append(response)
+
+        return [Response.merge_stream(*stream) for stream in streams]
+    


### PR DESCRIPTION
It's a mass commit, we have:
1. solve the issue that ray `deployment` exclusive for `generator` and `normal rest`
2. build in pipelines: `default` (transformer auto class) and `llamacpp` support streaming
3. `streaming` and `predict`(non stream) adopt one copy of code, avoid duplicated code
4. streaming also support ray batch
5. api consistent