### PR TITLE
deepspeed cannot work, since the input token not addressed on right device

### DIFF
--- a/llmserve/backend/llm/pipelines/_base.py
+++ b/llmserve/backend/llm/pipelines/_base.py
@@ -169,7 +169,7 @@ class BasePipeline(ABC):
         model_inputs = self.preprocess(inputs, **preprocess_params)
 
         model_inputs = self._ensure_tensor_on_device(
-            model_inputs, device=(self.model.device if hasattr(self.model, 'device') else self.device))
+            model_inputs, device=(self.model.device if hasattr(self.model, 'device') else self.model.module.device if hasattr(self.model, 'module') else self.device))
         
         forward_params = self._add_default_generate_kwargs(
             forward_params, model_inputs)


### PR DESCRIPTION
Address the `input token` to device, we adopt `to(model.device)`, but for deepspeed, it hide the real model to `model.module`