### PR TITLE
correct generated metric

### DIFF
--- a/llmserve/backend/llm/engines/vllm/vllm.py
+++ b/llmserve/backend/llm/engines/vllm/vllm.py
@@ -196,7 +196,6 @@ class VllmEngine(LLMEngine):
         )
 
         logger.info(f"final generate params: {sampling_params}")
-        st = time.monotonic()
         request_id = str(uuid.uuid4())
         tokenizer = self.engine.engine.tokenizer
         prompt_text = inputs[0]
@@ -212,6 +211,7 @@ class VllmEngine(LLMEngine):
 
         logger.info(f"final prompt is: {prompt_text}")
         # Construct a results generator from VLLM
+        st = time.monotonic()
         results_generator: AsyncIterator[RequestOutput] = self.engine.generate(
             prompt_text,
             self._parse_sampling_params(sampling_params),
@@ -249,6 +249,7 @@ class VllmEngine(LLMEngine):
                         generation_time=gen_time,
                     )
                 ]
+                st = time.monotonic()
             logger.info(
                 f"Request {request_id} finished ({finish_reason}). "
                 f"Total time: {(gen_time)}s, "

--- a/llmserve/backend/llm/pipelines/default_pipeline.py
+++ b/llmserve/backend/llm/pipelines/default_pipeline.py
@@ -149,7 +149,7 @@ class DefaultPipeline(StreamingPipeline):
         }
 
     def forward(self, model_inputs, **generate_kwargs):
-        st = time.monotonic()
+        # st = time.monotonic()
         inputs = model_inputs["inputs"]
         instruction_text = model_inputs["instruction_text"]
         prompt_text = model_inputs["prompt_text"]
@@ -167,12 +167,12 @@ class DefaultPipeline(StreamingPipeline):
         generation_kwargs = dict(inputs, streamer=streamer, **generate_kwargs)
         thread = Thread(target=self.model.generate, kwargs=generation_kwargs)
         thread.start()
+        st = time.monotonic()
         while True:
             try:
                 for token in streamer:
-                    et = time.monotonic() - st
-                    st = et
                     if token:
+                        et = time.monotonic() - st
                         yield {
                             "inputs": inputs,
                             "generated_sequence": [token],
@@ -182,6 +182,7 @@ class DefaultPipeline(StreamingPipeline):
                             "generation_time": et,
                             "generate_kwargs": generate_kwargs,
                         }
+                        st = time.monotonic()
                 break
             except Empty:
                 asyncio.sleep(0.001)
@@ -202,7 +203,7 @@ class DefaultPipeline(StreamingPipeline):
                 if inputs_unwrapped[i] != self.tokenizer.pad_token_id:
                     break
             num_input_tokens = len(inputs_unwrapped[i:])
-            num_generated_tokens = len(tokens)
+            num_generated_tokens = 1
             response = Response(
                 generated_text=tokens,
                 num_generated_tokens=num_generated_tokens,

--- a/llmserve/backend/llm/pipelines/llamacpp/llamacpp_pipeline.py
+++ b/llmserve/backend/llm/pipelines/llamacpp/llamacpp_pipeline.py
@@ -171,9 +171,9 @@ class LlamaCppPipeline(StreamingPipeline):
                 kwargs.pop('stopping_criteria', None)
                 kwargs.pop('echo', None)
                 logger.info(f"chat generate_kwargs: {kwargs}")
+                st = time.monotonic()
                 output = self.model.create_chat_completion(messages=input, stream=True, **kwargs)
                 for chunk in output:
-                    st = time.monotonic()
                     gen_time = time.monotonic() - st
                     delta = chunk['choices'][0]['delta']
                     
@@ -208,11 +208,12 @@ class LlamaCppPipeline(StreamingPipeline):
                             )
                             for i in range(batch_size)   
                         ]
+                        st = time.monotonic()
             else:
                 logger.info(f"generate_kwargs: {kwargs}")
+                st = time.monotonic()
                 output = self.model(input, stream=True, **kwargs)
                 for token in output:
-                    st = time.monotonic()
                     gen_time = time.monotonic() - st
                     chunk = token["choices"][0]["text"].replace("\u200b", "")
                     # logger.info(f'LlamaCppPipeline -> generate -> Yield -> "{chunk}"')
@@ -241,6 +242,7 @@ class LlamaCppPipeline(StreamingPipeline):
                         )
                         for i in range(batch_size)   
                     ]
+                    st = time.monotonic()
 
 
     def _sanitize_gen_parameters(

--- a/llmserve/backend/server/models.py
+++ b/llmserve/backend/server/models.py
@@ -185,6 +185,13 @@ class Response(ComputedPropertyMixin, BaseModelExtended):
         ]
         generation_time = sum(generation_time) if generation_time else None
 
+        postprocessing_time = [
+            response.postprocessing_time
+            for response in responses
+            if response.postprocessing_time is not None
+        ]
+        postprocessing_time = sum(postprocessing_time) if postprocessing_time else None
+
         return cls(
             generated_text=generated_text,
             num_input_tokens=num_input_tokens,
@@ -193,6 +200,7 @@ class Response(ComputedPropertyMixin, BaseModelExtended):
             num_generated_tokens_batch=num_generated_tokens_batch,
             preprocessing_time=preprocessing_time,
             generation_time=generation_time,
+            postprocessing_time=postprocessing_time,
         )
     
     @property
@@ -205,7 +213,6 @@ class Response(ComputedPropertyMixin, BaseModelExtended):
             )
         except Exception:
             return None
-
     @property
     def num_total_tokens(self) -> Optional[float]:
         try:


### PR DESCRIPTION
something like this: the original `num_generated_tokens`, `generation_time` .etc are not correct
```
[{"generated_text":" Where are you from? What is your background? What is your training? What are your skills? How did you get here? How did you get to be in this position? Who are your clients? What do you do? What do you offer? What is your vision? What are your goals? What are your values? What are your standards? What is your approach? What is your process? What are your fees? What is your availability? What is your schedule? What is your response time? What is your guarantee? What is your satisfaction guarantee? What is your refund policy? What is your return policy?","num_input_tokens":4,"num_input_tokens_batch":4,"num_generated_tokens":125,"num_generated_tokens_batch":125,"preprocessing_time":null,"generation_time":2.3241713171009906,"postprocessing_time":null,"generation_time_per_token":0.018016831915511556,"generation_time_per_token_batch":0.018016831915511556,"num_total_tokens":129,"num_total_tokens_batch":129,"total_time":null,"total_time_per_token":null,"total_time_per_token_batch":null}]
```